### PR TITLE
Fix lookup of subdomains

### DIFF
--- a/modules/lookup.js
+++ b/modules/lookup.js
@@ -61,6 +61,7 @@ class Lookup {
 
                 if (rd['domains'][this.metadata['tld']]) {
                     this.server = rd['domains'][this.metadata['tld']]
+                    this.target = this.metadata['domain']
                     this.type = "domain"
                 } else {
                     this.type = "unsupported-domain"


### PR DESCRIPTION
Fix RDAP lookup of subdomains.

Examples:
- https://rdap.cloud/api/v1/workers.cloudflare.com (worker error)
- https://rdap.cloud/api/v1/something.cloudflare.xyz (tld resolver returns invalid data)